### PR TITLE
fix(header): ドロップダウン先頭の冗長な display_name 表示を削除 (Closes #94)

### DIFF
--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -273,16 +273,6 @@ export default function Header() {
                     align="end"
                     sideOffset={5}
                   >
-                    <DropdownMenu.Item
-                      className="flex cursor-pointer items-center space-x-2 rounded-md px-3 py-2 text-sm text-gray-300 outline-none hover:bg-gray-700 hover:text-white focus:bg-gray-700 focus:text-white"
-                      disabled
-                    >
-                      <UserIcon className="h-4 w-4" />
-                      <span className="truncate">
-                        {profileDisplayName || ''}
-                      </span>
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Separator className="my-1 h-px bg-gray-700" />
                     <Link href="/profile" className="w-full">
                       <DropdownMenu.Item
                         className="flex cursor-pointer items-center space-x-2 rounded-md px-3 py-2 text-sm text-gray-300 outline-none hover:bg-gray-700 hover:text-white focus:bg-gray-700 focus:text-white"

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -374,9 +374,6 @@ export default function Header() {
                 </div>
               ) : user ? (
                 <>
-                  <div className="px-3 py-2 text-sm text-gray-400">
-                    {profileDisplayName || ''}
-                  </div>
                   <Link
                     href="/profile"
                     onClick={() => setMobileMenuOpen(false)}


### PR DESCRIPTION
## 概要

ヘッダー右上ユーザーメニューの先頭にあった `disabled` アイテム (人アイコン + `profileDisplayName`) を削除。アバターボタンに既に同じ名前が出ており情報重複、かつ未設定ユーザーでは空ラベル＋アイコンだけが残って意味不明だった。デスクトップ/モバイル両方で対応。

## 変更内容

- `app/components/layout/Header.tsx:276-284` — デスクトップドロップダウンの disabled item と下の Separator を削除
- `app/components/layout/Header.tsx:387-389` — モバイルメニューのログイン後先頭の name ラベル行を削除

結果、ドロップダウンは「マイページ / ログアウト」の2項目構成に、モバイルメニューはログイン後すぐにマイページリンクから始まる。

## 処理フロー (変更前/後の比較)

\`\`\`mermaid
flowchart LR
    subgraph Before["変更前: デスクトップ Dropdown"]
        B1[冗長: 人アイコン + display_name]
        B2[--- Separator ---]
        B3[マイページ]
        B4[--- Separator ---]
        B5[ログアウト]
        B1 --> B2 --> B3 --> B4 --> B5
    end

    subgraph After["変更後: デスクトップ Dropdown"]
        A1[マイページ]
        A2[--- Separator ---]
        A3[ログアウト]
        A1 --> A2 --> A3
    end

    Before -.簡潔化.-> After
\`\`\`

## テスト

- [x] \`npm run lint\` — 0 errors
- [x] \`npm run test -- --run app/components/layout/__tests__/Header.test.tsx\` — 33 passed
- [x] 手動確認: localhost で desktop/mobile 両方のメニュー表示を目視

## 関連Issue

Closes #94