### PR TITLE
chore(masters): ブキマスタ不足ブキ追加 & モップリンD→モップリン リネーム (Closes #98)

### DIFF
--- a/supabase/migrations/012_add_missing_weapons.sql
+++ b/supabase/migrations/012_add_missing_weapons.sql
@@ -1,0 +1,28 @@
+-- サーモンラン対応ブキのマスタ整備
+-- 参考: https://gamepedia.jp/splatoon3/archives/15178
+--
+-- 1. 既存の「モップリンD」を正式名称「モップリン」にリネーム
+--    （id および外部キー参照を保持するため、DELETE/INSERT ではなく UPDATE で対応）
+-- 2. 参考サイトに記載があるが m_weapons に未登録のブキを追加
+
+-- 1. モップリンD → モップリン
+UPDATE m_weapons
+SET name = 'モップリン'
+WHERE name = 'モップリンD';
+
+-- 2. 不足ブキの追加
+INSERT INTO m_weapons (name, icon_url, is_grizzco_weapon)
+SELECT
+  (item->>'name')::VARCHAR AS name,
+  NULLIF(item->>'icon_url', 'null')::TEXT AS icon_url,
+  COALESCE((item->>'is_grizzco_weapon')::BOOLEAN, false) AS is_grizzco_weapon
+FROM jsonb_array_elements('[
+  {"name": "スペースシューター", "icon_url": null, "is_grizzco_weapon": false},
+  {"name": "14式竹筒銃・甲", "icon_url": null, "is_grizzco_weapon": false},
+  {"name": "R-PEN/5H", "icon_url": null, "is_grizzco_weapon": false},
+  {"name": "S-BLAST92", "icon_url": null, "is_grizzco_weapon": false},
+  {"name": "イグザミナー", "icon_url": null, "is_grizzco_weapon": false},
+  {"name": "フィンセント", "icon_url": null, "is_grizzco_weapon": false},
+  {"name": "フルイドV", "icon_url": null, "is_grizzco_weapon": false}
+]'::jsonb) AS item
+ON CONFLICT (name) DO NOTHING;

--- a/supabase/seed/m_weapons.json
+++ b/supabase/seed/m_weapons.json
@@ -305,7 +305,7 @@
     "is_grizzco_weapon": false
   },
   {
-    "name": "モップリンD",
+    "name": "モップリン",
     "icon_url": null,
     "is_grizzco_weapon": false
   },
@@ -363,6 +363,41 @@
     "name": "クマサン印のローラー",
     "icon_url": null,
     "is_grizzco_weapon": true
+  },
+  {
+    "name": "スペースシューター",
+    "icon_url": null,
+    "is_grizzco_weapon": false
+  },
+  {
+    "name": "14式竹筒銃・甲",
+    "icon_url": null,
+    "is_grizzco_weapon": false
+  },
+  {
+    "name": "R-PEN/5H",
+    "icon_url": null,
+    "is_grizzco_weapon": false
+  },
+  {
+    "name": "S-BLAST92",
+    "icon_url": null,
+    "is_grizzco_weapon": false
+  },
+  {
+    "name": "イグザミナー",
+    "icon_url": null,
+    "is_grizzco_weapon": false
+  },
+  {
+    "name": "フィンセント",
+    "icon_url": null,
+    "is_grizzco_weapon": false
+  },
+  {
+    "name": "フルイドV",
+    "icon_url": null,
+    "is_grizzco_weapon": false
   },
   {
     "name": "緑ランダム",


### PR DESCRIPTION
## 概要

サーモンラン対応ブキ一覧（参考: https://gamepedia.jp/splatoon3/archives/15178 ）と現行の `m_weapons` マスタを照合し、不足していた 7 件のブキを追加するとともに、表記揺れのあった `モップリンD` を正式名称の `モップリン` にリネームする。

Closes #98

## 変更内容

### リネーム（UPDATE）

- `モップリンD` → `モップリン`
  - 既存レコードの `id` および外部キー参照（`scenarios` 等）を保持するため、DELETE+INSERT ではなく `UPDATE` で対応

### 追加（7 件）

| カテゴリ | 名称 |
| --- | --- |
| シューター | スペースシューター |
| チャージャー | 14式竹筒銃・甲 |
| チャージャー | R-PEN/5H |
| ブラスター | S-BLAST92 |
| スピナー | イグザミナー |
| フデ | フィンセント |
| ストリンガー | フルイドV |

いずれも `is_grizzco_weapon = false`、`icon_url = null` で登録。

### 対象ファイル

- `supabase/migrations/012_add_missing_weapons.sql`（新規）
- `supabase/seed/m_weapons.json`（既存マスタ seed も同期）

## 処理フロー

\`\`\`mermaid
sequenceDiagram
    participant Dev as 開発者
    participant Supabase
    participant DB as m_weapons

    Dev->>Supabase: migration 012 を適用
    Supabase->>DB: UPDATE name='モップリン' WHERE name='モップリンD'
    DB-->>Supabase: id 保持のまま名称更新
    Supabase->>DB: INSERT ... jsonb_array_elements(7件)<br/>ON CONFLICT DO NOTHING
    DB-->>Supabase: 新規ブキ 7 件追加
    Supabase-->>Dev: マスタ整備完了
\`\`\`

## 背景

Gemini による画像解析でブキ名判定の精度を上げる前段として、マスタデータ自体の網羅性を担保しておく必要がある。不足ブキがあるとファジーマッチでも補完できないため、先行してマスタ整備を行う。

## テスト

- [x] `npm run lint` — エラー 0 件（既存の 2 warnings のみ、本 PR とは無関係）
- [x] `npm run test -- --run` — 438 passed / 2 skipped
- [ ] Supabase プロジェクトへの migration 適用（マージ後、手動で `supabase db push` 等を実施）

## 注意事項

- ブキ件数に依存したテストは存在しないことを確認済み。
- `ON CONFLICT (name) DO NOTHING` のため、`モップリン` を先に INSERT するような順序ミスを防ぐ意図で、本 migration は「先に UPDATE（リネーム）→ 次に INSERT」の順で記述している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)