### PR TITLE
feat(analyze): 画像AI解析をログイン必須化（Closes #102）

### DIFF
--- a/app/api/__tests__/analyze.test.ts
+++ b/app/api/__tests__/analyze.test.ts
@@ -32,8 +32,16 @@ vi.mock('next/headers', () => ({
   ),
 }))
 
+const mockGetUser = vi.fn()
+
 vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn(),
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: {
+        getUser: mockGetUser,
+      },
+    })
+  ),
 }))
 
 describe('POST /api/analyze', () => {
@@ -75,10 +83,37 @@ describe('POST /api/analyze', () => {
       stages: ['アラマキ砦'],
       weapons: ['スプラシューター', 'スプラチャージャー'],
     })
+
+    // デフォルトで認証済みユーザーを返す
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'test-user-id' } },
+      error: null,
+    })
   })
 
   afterEach(() => {
     process.env = originalEnv
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: null,
+    })
+
+    const fileContent = new Uint8Array([1, 2, 3])
+    const request = new NextRequest('http://localhost:3000/api/analyze', {
+      method: 'POST',
+    })
+    const mockFormData = createMockFormDataWithFile(fileContent)
+    vi.spyOn(request, 'formData').mockResolvedValue(mockFormData)
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(data.success).toBe(false)
+    expect(data.error).toBe('認証が必要です')
   })
 
   it('returns 500 when GEMINI_API_KEY is not configured', async () => {

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI, MediaResolution } from '@google/genai'
 import { NextRequest, NextResponse } from 'next/server'
 import { buildAnalysisPrompt } from '@/lib/ai/prompt'
+import { createClient } from '@/lib/supabase/server'
 import { fetchMasterNames } from '@/lib/utils/master-names'
 import { lookupStageId, lookupWeaponIds } from '@/lib/utils/master-lookup'
 import type { AnalyzedScenario, AnalyzeResponse } from '@/app/types/analyze'
@@ -62,6 +63,20 @@ function buildResponseSchema(stages: string[]) {
 
 export async function POST(request: NextRequest): Promise<NextResponse<AnalyzeResponse>> {
   try {
+    // 認証チェック: 未ログインでの AI 解析利用を禁止（Gemini API 課金スパム対策）
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { success: false, error: '認証が必要です' },
+        { status: 401 }
+      )
+    }
+
     const apiKey = process.env.GEMINI_API_KEY
     if (!apiKey) {
       return NextResponse.json(

--- a/app/components/ImageAnalyzer.tsx
+++ b/app/components/ImageAnalyzer.tsx
@@ -19,6 +19,9 @@ import {
   Grid,
 } from '@mui/material'
 import { Upload, Clear, Save } from '@mui/icons-material'
+import { createClient } from '@/lib/supabase/client'
+import { signInWithGoogle } from '@/lib/auth/google-auth'
+import type { User } from '@supabase/supabase-js'
 import type { AnalyzedScenario, AnalyzeResponse, WaveInfo } from '@/app/types/analyze'
 
 interface Stage {
@@ -64,7 +67,39 @@ export default function ImageAnalyzer() {
   const [duplicateScenarioCode, setDuplicateScenarioCode] = useState<string | null>(null)
   const [stages, setStages] = useState<Stage[]>([])
   const [weapons, setWeapons] = useState<Weapon[]>([])
+  const [user, setUser] = useState<User | null>(null)
+  const [userLoading, setUserLoading] = useState(true)
   const abortControllerRef = useRef<AbortController | null>(null)
+
+  // ログイン状態を取得（AI解析はログイン必須のため）
+  useEffect(() => {
+    const supabase = createClient()
+    let isMounted = true
+
+    const loadUser = async () => {
+      const {
+        data: { user: currentUser },
+      } = await supabase.auth.getUser()
+      if (isMounted) {
+        setUser(currentUser)
+        setUserLoading(false)
+      }
+    }
+    loadUser()
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (isMounted) {
+        setUser(session?.user ?? null)
+      }
+    })
+
+    return () => {
+      isMounted = false
+      subscription.unsubscribe()
+    }
+  }, [])
 
   // プレビューURLのクリーンアップ
   useEffect(() => {
@@ -475,6 +510,36 @@ export default function ImageAnalyzer() {
         画像解析
       </Typography>
 
+      {/* ログイン必須の案内（未ログイン時のみ表示） */}
+      {!userLoading && !user && (
+        <Alert
+          severity="info"
+          sx={{
+            mb: { xs: 2, sm: 3 },
+            backgroundColor: 'rgba(30, 58, 138, 0.3)',
+            color: '#bfdbfe',
+            fontSize: { xs: '0.875rem', sm: '1rem' },
+          }}
+        >
+          <AlertTitle sx={{ fontSize: { xs: '0.9375rem', sm: '1rem' } }}>
+            ログインが必要です
+          </AlertTitle>
+          <Box sx={{ mb: 1.5 }}>
+            画像のAI解析をご利用いただくには、Googleアカウントでのログインが必要です。
+          </Box>
+          <Button
+            variant="contained"
+            onClick={() => signInWithGoogle()}
+            sx={{
+              backgroundColor: '#3b82f6',
+              '&:hover': { backgroundColor: '#2563eb' },
+            }}
+          >
+            Googleでログイン
+          </Button>
+        </Alert>
+      )}
+
       {/* 画像アップロード */}
       <Box sx={{ mb: { xs: 2, sm: 3 } }}>
         <input
@@ -483,14 +548,14 @@ export default function ImageAnalyzer() {
           accept="image/*"
           onChange={handleImageSelect}
           style={{ display: 'none' }}
-          disabled={isAnalyzing}
+          disabled={isAnalyzing || (!userLoading && !user)}
         />
         <Button
           variant="contained"
           component="label"
           startIcon={<Upload />}
           onClick={handleFileButtonClick}
-          disabled={isAnalyzing}
+          disabled={isAnalyzing || (!userLoading && !user)}
           fullWidth
           sx={{
             backgroundColor: '#3b82f6',
@@ -638,7 +703,7 @@ export default function ImageAnalyzer() {
         <Button
           variant="contained"
           onClick={handleAnalyze}
-          disabled={!selectedImage || isAnalyzing || isSaving}
+          disabled={!selectedImage || isAnalyzing || isSaving || (!userLoading && !user)}
           startIcon={isAnalyzing ? <CircularProgress size={16} sx={{ color: '#ffffff' }} /> : null}
           fullWidth
           sx={{

--- a/app/components/__tests__/ImageAnalyzer.test.tsx
+++ b/app/components/__tests__/ImageAnalyzer.test.tsx
@@ -10,6 +10,26 @@ vi.mock('next/navigation', () => ({
   useRouter: vi.fn(),
 }))
 
+// Supabaseクライアントをモック（デフォルトでログイン済みユーザーを返す）
+const { mockGetUser, mockOnAuthStateChange, mockUnsubscribe } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockOnAuthStateChange: vi.fn(),
+  mockUnsubscribe: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      getUser: mockGetUser,
+      onAuthStateChange: mockOnAuthStateChange,
+    },
+  })),
+}))
+
+vi.mock('@/lib/auth/google-auth', () => ({
+  signInWithGoogle: vi.fn(),
+}))
+
 // Material-UIのAutocompleteをモック
 vi.mock('@mui/material', async () => {
   const actual = await vi.importActual('@mui/material')
@@ -66,6 +86,16 @@ describe('ImageAnalyzer', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+
+    // デフォルトでログイン済みユーザーを返す
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'test-user-id' } },
+      error: null,
+    })
+    mockOnAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: mockUnsubscribe } },
+    })
+
     vi.mocked(useRouter).mockReturnValue({
       push: mockPush,
       refresh: mockRefresh,

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -214,17 +214,19 @@ export default function Header() {
             >
               一覧
             </Link>
-            <Link
-              href="/analyze"
-              className={cn(
-                'px-3 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap',
-                isActive('/analyze')
-                  ? 'bg-orange-500 text-white'
-                  : 'text-gray-300 hover:bg-gray-800 hover:text-white'
-              )}
-            >
-              投稿する
-            </Link>
+            {!loading && user && (
+              <Link
+                href="/analyze"
+                className={cn(
+                  'px-3 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap',
+                  isActive('/analyze')
+                    ? 'bg-orange-500 text-white'
+                    : 'text-gray-300 hover:bg-gray-800 hover:text-white'
+                )}
+              >
+                投稿する
+              </Link>
+            )}
             <Link
               href="/guide"
               className={cn(
@@ -344,18 +346,20 @@ export default function Header() {
               >
                 一覧
               </Link>
-              <Link
-                href="/analyze"
-                onClick={() => setMobileMenuOpen(false)}
-                className={cn(
-                  'px-3 py-2 rounded-md text-base font-medium transition-colors',
-                  isActive('/analyze')
-                    ? 'bg-orange-500 text-white'
-                    : 'text-gray-300 hover:bg-gray-800 hover:text-white'
-                )}
-              >
-                投稿する
-              </Link>
+              {!loading && user && (
+                <Link
+                  href="/analyze"
+                  onClick={() => setMobileMenuOpen(false)}
+                  className={cn(
+                    'px-3 py-2 rounded-md text-base font-medium transition-colors',
+                    isActive('/analyze')
+                      ? 'bg-orange-500 text-white'
+                      : 'text-gray-300 hover:bg-gray-800 hover:text-white'
+                  )}
+                >
+                  投稿する
+                </Link>
+              )}
               <Link
                 href="/guide"
                 onClick={() => setMobileMenuOpen(false)}

--- a/app/components/layout/__tests__/Header.test.tsx
+++ b/app/components/layout/__tests__/Header.test.tsx
@@ -583,13 +583,27 @@ describe('Header', () => {
       })
     })
 
-    it('should render all navigation links', async () => {
+    it('should render navigation links visible to guests', async () => {
       render(<Header />)
 
       await waitFor(() => {
         expect(screen.getByText('一覧')).toBeInTheDocument()
-        expect(screen.getByText('投稿する')).toBeInTheDocument()
         expect(screen.getByText('ガイド')).toBeInTheDocument()
+      })
+      // 未ログイン時は「投稿する」は表示しない（AI解析はログイン必須のため）
+      expect(screen.queryByText('投稿する')).not.toBeInTheDocument()
+    })
+
+    it('should show 投稿する link when user is logged in', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: createMockUser() },
+        error: null,
+      })
+
+      render(<Header />)
+
+      await waitFor(() => {
+        expect(screen.getByText('投稿する')).toBeInTheDocument()
       })
     })
   })


### PR DESCRIPTION
## 概要

画像AI解析 (/analyze) を**ログイン必須**に変更しました。現状、未ログインでも AI 解析 API を叩ける状態となっており、悪意あるユーザーが大量の画像をアップロードすることで Gemini API の課金額を意図的に増やす攻撃が成立してしまうため、これを防止します。

- シナリオの一覧・詳細の閲覧は **引き続き未ログインでも可能** です
- ログインを必須とするのは AI 解析 (画像アップロード) と投稿 (保存) のみ

Closes #102

## 変更内容

### API 層 (最終防衛ライン)
- `app/api/analyze/route.ts` に `supabase.auth.getUser()` による認証ガードを追加
- 未ログイン時は **401 Unauthorized** を返して即座に処理を終了

### UI 層 (UX 改善)
- `app/components/layout/Header.tsx`: 未ログイン時は「投稿する」リンクをデスクトップ/モバイル両方で非表示
- `app/components/ImageAnalyzer.tsx`:
  - 未ログイン時に「Googleでログイン」ボタン付きの案内 Alert を表示
  - 画像選択ボタン・解析ボタンを未ログイン時 (認証状態判定完了後) に disable
  - 認証ロード中は disable しない（体感的な引っかかりを避けるため。最終防衛は API 層で担保）

### テスト
- `app/api/__tests__/analyze.test.ts`:
  - supabase 認証モックを追加 (beforeEach で `getUser` が user を返すデフォルトを設定)
  - **新規**: 未認証時に 401 を返すテストを追加
- `app/components/layout/__tests__/Header.test.tsx`:
  - 未ログイン時に「投稿する」が表示されないことを確認
  - **新規**: ログイン時に「投稿する」が表示されるテストを追加
- `app/components/__tests__/ImageAnalyzer.test.tsx`:
  - supabase クライアント / `signInWithGoogle` モックを追加 (デフォルトログイン済み)

## 処理フロー

```mermaid
sequenceDiagram
    participant User as 未ログインユーザー
    participant Header as Header
    participant Analyze as /analyze
    participant API as /api/analyze
    participant Supabase as Supabase Auth

    User->>Header: ヘッダー表示
    Header->>Supabase: auth.getUser()
    Supabase-->>Header: user=null
    Note over Header: 「投稿する」リンクを非表示

    User->>Analyze: /analyze を直打ちで訪問
    Analyze->>Supabase: auth.getUser()
    Supabase-->>Analyze: user=null
    Note over Analyze: Alert「ログインが必要」+<br/>画像選択/解析ボタン disable

    User->>API: (curl 等で直接リクエスト)
    API->>Supabase: auth.getUser()
    Supabase-->>API: user=null
    API-->>User: 401 Unauthorized
    Note over API: Gemini API 呼び出し前に<br/>必ず遮断（課金スパム防止）
```

## 設計上のポイント

- **多層防御**: UI gating (Header 非表示 / ボタン disable / 案内 Alert) はユーザビリティのため、**真の防衛ラインは API 側の 401**
- 認証ロード中は UI を disable しない: `mockGetUser` が未解決な瞬間にボタンが一瞬 disable → enabled と点滅するのを避け、ユーザーが UI 操作で引っかからないようにしつつ、最終的な悪用は API 層で確実に防ぐ

## テスト
- [x] 単体テスト 440 件すべて pass
- [x] `npm run lint` エラーなし
- [ ] Vercel Preview にて
  - [ ] 未ログインで `/analyze` を訪問 → Alert が表示され、画像選択/解析ボタンが disable になっている
  - [ ] 未ログインで `/api/analyze` に curl で画像 POST → 401 が返る
  - [ ] Google ログイン後、「投稿する」リンクが表示され、通常通り解析できる
  - [ ] 未ログインでもシナリオ一覧/詳細が閲覧できる

## 関連 Issue
Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)